### PR TITLE
sys-devel/gettext: avoid Autotools regeneration in 0.21 and 0.19.8.1

### DIFF
--- a/sys-devel/gettext/gettext-0.19.8.1.ebuild
+++ b/sys-devel/gettext/gettext-0.19.8.1.ebuild
@@ -54,6 +54,10 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-0.19.7-disable-libintl.patch #564168
 	epatch "${FILESDIR}"/${PN}-0.19.8.1-format-security.patch
 
+	# Avoid triggering Autotools regeneration due to modification of
+	# gettext.m4 in gettext-0.19.7-disable-libintl.patch
+	touch -r gettext-runtime/m4/iconv.m4 gettext-runtime/m4/gettext.m4
+
 	if use elibc_Cygwin; then
 		epatch "${FILESDIR}"/0.19.8.1-no-woe32dll.patch
 		epatch "${FILESDIR}"/0.19.3-localename.patch

--- a/sys-devel/gettext/gettext-0.21.ebuild
+++ b/sys-devel/gettext/gettext-0.21.ebuild
@@ -84,6 +84,10 @@ src_prepare() {
 
 	default
 
+	# Avoid triggering Autotools regeneration due to modification of
+	# gettext.m4 in gettext-0.19.7-disable-libintl.patch
+	touch -r gettext-runtime/m4/iconv.m4 gettext-runtime/m4/gettext.m4
+
 	# this script uses syntax that Solaris /bin/sh doesn't grok
 	sed -i -e '1c\#!/usr/bin/env sh' \
 		gettext-tools/misc/convert-archive.in || die


### PR DESCRIPTION
Avoid triggering Autotools regeneration due to modification of
gettext.m4 in gettext-0.19.7-disable-libintl.patch

This addresses the issue with 0.21 identified in c4451b76dc4f269b5ce467fb3f8fa888bb202ac5,
which inadvertently caused the same issue with 0.19.8.1 since both versions rely
on the same patch file.

It should now be possible to unmask 0.21

CC @thesamesam @grobian