### PR TITLE
Use --deep and --newuse

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2162,10 +2162,10 @@ bootstrap_stage3() {
 	# Avoid glib compiling for Cocoa libs if it finds them, since we're
 	# still with an old llvm that may not understand the system headers
 	# very well on Darwin (-DGNUSTEP_BASE_VERSION hack)
-	einfo "running emerge -u system"
-	estatus "stage3: emerge -u system"
+	einfo "running emerge -uDNav system"
+	estatus "stage3: emerge -uDNav system"
 	CPPFLAGS="-DGNUSTEP_BASE_VERSION" \
-	CFLAGS= CXXFLAGS= emerge --color n -u -v system || return 1
+	CFLAGS= CXXFLAGS= emerge --color n -uDNav system || return 1
 
 	# remove anything that we don't need (compilers most likely)
 	einfo "running emerge --depclean"


### PR DESCRIPTION
To capture dependency updates and build with updated USE flags prior to emerge -e system - will avoid potential unresolved dependency situations