### PR TITLE
Unsetting CFLAGS and CXXFLAGS by stage3 breaks builds

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2171,7 +2171,7 @@ bootstrap_stage3() {
 	einfo "running emerge -uDNav system"
 	estatus "stage3: emerge -uDNav system"
 	CPPFLAGS="-DGNUSTEP_BASE_VERSION" \
-	CFLAGS= CXXFLAGS= emerge --color n -uDNav system || return 1
+	emerge --color n -uDNav system || return 1
 
 	# remove anything that we don't need (compilers most likely)
 	einfo "running emerge --depclean"


### PR DESCRIPTION
By stage3 we encounter failures in coreutils and libtasn1 with CFLAGS and CXXFLAGS unset. Build proceeds normally for all packages without doing this. 

Cleaning the environment during build makes sense, but a user will be updating system packages with a potentially polluted environment later on anyway...

Maybe it'd be better to include a note at the start of the bootstrap script that the shell environment should be free from compiler flags?