### PR TITLE
bootstrap-prefix.sh fixes for stage1 cygwin bash and python failures

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -941,7 +941,7 @@ bootstrap_gnu() {
 	# Darwin9 in particular doesn't compile when using system readline,
 	# but we don't need any groovy input at all, so just disable it,
 	# except for Cygwin, where the patch above would fail to compile
-	[[ ${PN} == "bash" && ${CHOST} != *-cygwin* ]] \
+	[[ ${PN} == "bash" ]] \
 		&& myconf="${myconf} --disable-readline"
 
 	# on e.g. musl systems bash will crash with a malloc error if we use
@@ -1054,17 +1054,36 @@ bootstrap_python() {
 	case ${CHOST} in
 	(*-*-cygwin*)
 		# apply patches from cygwinports much like the ebuild does
-		local gitrev pf pn
-		gitrev="71f2ac2444946c97d892be3892e47d2a509e0e96" # python36 3.6.8
-		efetch "https://github.com/cygwinports/python36/archive/${gitrev}.tar.gz" \
-			|| return 1
-		gzip -dc "${DISTDIR}"/${gitrev}.tar.gz | tar -xf -
-		[[ ${PIPESTATUS[*]} == '0 0' ]] || return 1
+		local gitrev cygpyver pf pn patch_folder ffail
+
+		# try github first, if that fails, it means that cygwin has not archived that repo yet
+		# ideally the version of python used by bootstrap would be one that cygwin has packaged
+		# if we don't do exact matches on the version then some patches may not apply cleanly
+
+		ffail=0
+		gitrev="42494e325a050ba03638568d7318f8f0075e25fb"
+		efetch "https://github.com/cygwinports/python39/archive/${gitrev}.tar.gz" \
+			|| ffail=1
+		if [[ -z ${ffail} ]]; then
+			gzip -dc "${DISTDIR}"/"${gitrev}.tar.gz" | tar -xf -
+			[[ ${PIPESTATUS[*]} == '0 0' ]] || return 1
+			patch_folder="python39-${gitrev}"
+		else
+			cygpyver="3.9.9-1"
+			efetch "https://mirrors.kernel.org/sourceware/cygwin/x86_64/release/python39/python39-${cygpyver}-src.tar.xz" \
+				|| return 1
+			xz -dc "${DISTDIR}"/"python39-${cygpyver}-src.tar.xz" | tar -xf -
+			[[ ${PIPESTATUS[*]} == '0 0' ]] || return 1
+			patch_folder="python39-${cygpyver}.src"
+			ffail=0
+		fi
+		[[ ${ffail} == 0 ]] || return 1
+
 		for pf in $(
 			sed -ne '/PATCH_URI="/,/"/{s/.*="//;s/".*$//;p}' \
-			< python36-${gitrev}/python3.cygport
+			< "${patch_folder}/python39.cygport" | grep -v rpm-wheels | grep -v revert-bpo
 		); do
-			pf="python36-${gitrev}/${pf}"
+			pf="${patch_folder}/${pf}"
 			for pn in {1..2} fail; do
 				if [[ ${pn} == fail ]]; then
 					eerror "failed to apply ${pf}"


### PR DESCRIPTION
bootstrap_gnu --disable-readline seems to work and seems to be needed
on cygwin now for bash 5.1 and cygwin-3.3.5-341

bootstrap_python update patches to use cygwin python39 patch set for
3.9.9 and source from their releases since only older versions are on
github and their gitweb does not support downloading snapshots,
requiring git, which makes it unsuitable for bootstrapping

I'm not sure whether this is the right approach, and I have only tested this on a single Windows 11 machine (though in principle I have some other versions I could test against).

This is likely needed to be able to get a working prefix on windows to debug https://bugs.gentoo.org/852665.