### PR TITLE
scripts/bootstrap-prefix: fallback python tarball to .tgz if no xz

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -1000,7 +1000,11 @@ bootstrap_gnu() {
 PYTHONMAJMIN=3.10   # keep this number in line with PV below for stage1,2
 bootstrap_python() {
 	PV=3.10.4
-	A=Python-${PV}.tar.xz
+	if type -P xz > /dev/null ; then
+		A=Python-${PV}.tar.xz
+	else
+		A=Python-${PV}.tgz
+	fi
 	einfo "Bootstrapping ${A%.tar.*}"
 
 	efetch https://www.python.org/ftp/python/${PV}/${A}
@@ -1013,6 +1017,7 @@ bootstrap_python() {
 	case ${A} in
 		*bz2) bzip2 -dc "${DISTDIR}"/${A} | tar -xf - ;;
 		*xz)  xz -dc "${DISTDIR}"/${A} | tar -xf -    ;;
+		*tgz) gzip -dc "${DISTDIR}"/${A} | tar -xf -  ;;
 		*)    einfo "Don't know to unpack ${A}"       ;;
 	esac
 	[[ ${PIPESTATUS[*]} == '0 0' ]] || return 1


### PR DESCRIPTION
Currently in stage1, `Python-${PV}.tar.xz` is downloaded. However, in systems without `xz`, extracting would fail.
https://github.com/gentoo/prefix/blob/1e10173683711f9c2d6d5b93ac6462d274459510/scripts/bootstrap-prefix.sh#L1015

We can have a check first, and fallback to use `Python-${PV}.tgz` if no `xz` found.

PS. I am on macOS Ventura 13.1, and there is no `xz` out of box.