### PR TITLE
Fix GCC 12 on Apple M1 and macOS 13, allowing stage2 & stage3 bootstrap

### DIFF
--- a/sys-devel/gcc/files/gcc-12.1.0-avoid-null-terminated-name-collision-with-macos-13-sdk.patch
+++ b/sys-devel/gcc/files/gcc-12.1.0-avoid-null-terminated-name-collision-with-macos-13-sdk.patch
@@ -1,0 +1,85 @@
+https://bugs.gentoo.org/886491
+https://bugs.gentoo.org/895332
+https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=d1201dbf55a11d391030914985ba6b443e59baa5
+
+From d1201dbf55a11d391030914985ba6b443e59baa5 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Mon, 13 Jun 2022 16:40:19 +0100
+Subject: [PATCH] libstdc++: Rename __null_terminated to avoid collision with
+ Apple SDK
+
+The macOS 13 SDK (and equivalent-version iOS and other Apple OS SDKs)
+contain this definition in <sys/cdefs.h>:
+
+863  #define __null_terminated
+
+This collides with the use of __null_terminated in libstdc++'s
+experimental fs_path.h.
+
+As libstdc++'s use of this token is entirely internal to fs_path.h, the
+simplest workaround, renaming it, is most appropriate. Here, it's
+renamed to __nul_terminated, referencing the NUL ('\0') value that is
+used to terminate the strings in the context in which this tag structure
+is used.
+
+libstdc++-v3/ChangeLog:
+
+	* include/experimental/bits/fs_path.h (__detail::__null_terminated):
+	Rename to __nul_terminated to avoid colliding with a macro in
+	Apple's SDK.
+
+Signed-off-by: Mark Mentovai <mark@mentovai.com>
+(cherry picked from commit 254e88b3d7e8abcc236be3451609834371cf4d5d)
+---
+ libstdc++-v3/include/experimental/bits/fs_path.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/libstdc++-v3/include/experimental/bits/fs_path.h b/libstdc++-v3/include/experimental/bits/fs_path.h
+index b0825ba76e80..19d246100cb5 100644
+--- a/libstdc++-v3/include/experimental/bits/fs_path.h
++++ b/libstdc++-v3/include/experimental/bits/fs_path.h
+@@ -140,10 +140,10 @@ namespace __detail
+     inline _Source
+     _S_range_begin(_Source __begin) { return __begin; }
+ 
+-  struct __null_terminated { };
++  struct __nul_terminated { };
+ 
+   template<typename _Source>
+-    inline __null_terminated
++    inline __nul_terminated
+     _S_range_end(_Source) { return {}; }
+ 
+   template<typename _CharT, typename _Traits, typename _Alloc>
+@@ -459,11 +459,11 @@ namespace __detail
+       struct _Cvt;
+ 
+     static string_type
+-    _S_convert(value_type* __src, __detail::__null_terminated)
++    _S_convert(value_type* __src, __detail::__nul_terminated)
+     { return string_type(__src); }
+ 
+     static string_type
+-    _S_convert(const value_type* __src, __detail::__null_terminated)
++    _S_convert(const value_type* __src, __detail::__nul_terminated)
+     { return string_type(__src); }
+ 
+     template<typename _Iter>
+@@ -477,7 +477,7 @@ namespace __detail
+ 
+     template<typename _InputIterator>
+       static string_type
+-      _S_convert(_InputIterator __src, __detail::__null_terminated)
++      _S_convert(_InputIterator __src, __detail::__nul_terminated)
+       {
+ 	auto __s = _S_string_from_iter(__src);
+ 	return _S_convert(__s.c_str(), __s.c_str() + __s.size());
+@@ -504,7 +504,7 @@ namespace __detail
+ 
+     template<typename _InputIterator>
+       static string_type
+-      _S_convert_loc(_InputIterator __src, __detail::__null_terminated,
++      _S_convert_loc(_InputIterator __src, __detail::__nul_terminated,
+ 		     const std::locale& __loc)
+       {
+ 	const std::string __s = _S_string_from_iter(__src);

--- a/sys-devel/gcc/files/gcc-12.1.0-recognize-mmacosx-version-min-13.0-and-newer.patch
+++ b/sys-devel/gcc/files/gcc-12.1.0-recognize-mmacosx-version-min-13.0-and-newer.patch
@@ -1,0 +1,54 @@
+https://bugs.gentoo.org/886491
+https://bugs.gentoo.org/895332
+https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=6725f186cb70d48338f69456864bf469a12ee5be
+
+From 6725f186cb70d48338f69456864bf469a12ee5be Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Fri, 10 Jun 2022 15:56:42 +0100
+Subject: [PATCH] Darwin: Future-proof -mmacosx-version-min
+
+f18cbc1ee1f4 (2021-12-18) updated various parts of gcc to not impose a
+Darwin or macOS version maximum of the current known release. Different
+parts of gcc accept, variously, Darwin version numbers matching
+darwin2*, and macOS major version numbers up to 99. The current released
+version is Darwin 21 and macOS 12, with Darwin 22 and macOS 13 expected
+for public release later this year. With one major OS release per year,
+this strategy is expected to provide another 8 years of headroom.
+
+However, f18cbc1ee1f4 missed config/darwin-c.c (now .cc), which
+continued to impose a maximum of macOS 12 on the -mmacosx-version-min
+compiler driver argument. This was last updated from 11 to 12 in
+11b967577483 (2021-10-27), but kicking the can down the road one year at
+a time is not a viable strategy, and is not in line with the more recent
+technique from f18cbc1ee1f4.
+
+Prior to 556ab5125912 (2020-11-06), config/darwin-c.c did not impose a
+maximum that needed annual maintenance, as at that point, all macOS
+releases had used a major version of 10. The stricter approach imposed
+since then was valuable for a time until the particulars of the new
+versioning scheme were established and understood, but now that they
+are, it's prudent to restore a more permissive approach.
+
+gcc/ChangeLog:
+
+	* config/darwin-c.cc: Make -mmacosx-version-min more future-proof.
+
+Signed-off-by: Mark Mentovai <mark@mentovai.com>
+---
+ gcc/config/darwin-c.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/darwin-c.cc b/gcc/config/darwin-c.cc
+index 9203c84d2c26c..1f82b36d2de10 100644
+--- a/gcc/config/darwin-c.cc
++++ b/gcc/config/darwin-c.cc
+@@ -691,7 +691,8 @@ macosx_version_as_macro (void)
+   if (!version_array)
+     goto fail;
+ 
+-  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 12)
++  /* System tools accept up to 99 as a major version.  */
++  if (version_array[MAJOR] < 10 || version_array[MAJOR] > 99)
+     goto fail;
+ 
+   if (version_array[MAJOR] == 10 && version_array[MINOR] < 10)

--- a/sys-devel/gcc/gcc-12.1.0.ebuild
+++ b/sys-devel/gcc/gcc-12.1.0.ebuild
@@ -45,6 +45,10 @@ src_prepare() {
 
 	eapply_user
 
+	# fix build for macOS 13 Ventura
+	eapply "${FILESDIR}"/gcc-12.1.0-recognize-mmacosx-version-min-13.0-and-newer.patch
+	eapply "${FILESDIR}"/gcc-12.1.0-avoid-null-terminated-name-collision-with-macos-13-sdk.patch
+
 	# make sure 64-bits native targets don't screw up the linker paths
 	eapply "${FILESDIR}"/gcc-12-no-libs-for-startfile.patch
 	if use prefix; then

--- a/sys-devel/gcc/gcc-12.2.0.ebuild
+++ b/sys-devel/gcc/gcc-12.2.0.ebuild
@@ -15,7 +15,7 @@ inherit toolchain
 if ! tc_is_live && [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	# fails to compile on Solaris and macOS, need to check why
 	: KEYWORDS="~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	KEYWORDS="~x64-macos ~x64-solaris ~x86-solaris"
+	KEYWORDS="~x64-solaris ~x86-solaris"
 fi
 
 # use alternate source for Apple M1 (also works for x86_64)


### PR DESCRIPTION
These commits fix Gentoo [Bug 895334](https://bugs.gentoo.org/show_bug.cgi?id=895334) and [Bug 895332](https://bugs.gentoo.org/show_bug.cgi?id=895332) with two changes.

### 1. mask sys-devel/gcc-12.2.0 on macOS as it's currently broken in bootstrap and the solution is still unclear

When bootstrapping Gentoo Prefix on macOS 13.2 (Ventura) on an Apple M1 system, it will fail at stage2 due to a sys-devel/gcc-12.2.0 build failure.

```
make[3]: Entering directory '/Users/leo/Gentoo/tmp/var/tmp/portage/sys-devel/gcc-12.2.0/work/build/libcc1'
/Users/leo/Gentoo/tmp/bin/bash ./libtool --tag=CXX   --mode=link g++ -m64 -std=gnu++11 -W -Wall  -fvisibility=hidden  -Wl,-undefined,dynamic_lookup -I/Users/leo/Gentoo/tmp/usr/include -pipe -O2 -module -export-symbols /Users/leo/Gentoo/tmp/var/tmp/portage/sys-devel/gcc-12.2.0/work/gcc-12-branch-gcc-12.2-darwin-r0/libcc1/libcc1.sym -Wc,-nodefaultrpaths,-nodefaultexport -Wl,-rpath,@loader_path  '-Wl,-search_paths_first' '-L/Users/leo/Gentoo/tmp/usr/lib' -o libcc1.la -rpath /Users/leo/Gentoo/tmp/usr/lib/ findcomp.lo libcc1.lo libcp1.lo compiler.lo names.lo callbacks.lo connection.lo marshall.lo    -Wc,../libiberty/pic/libiberty.a
libtool: link: sed -e 's,^,_,' < /Users/leo/Gentoo/tmp/var/tmp/portage/sys-devel/gcc-12.2.0/work/gcc-12-branch-gcc-12.2-darwin-r0/libcc1/libcc1.sym > .libs/libcc1-symbols.expsym
libtool: link: g++ -m64 -std=gnu++11  -o .libs/libcc1.0.so -bundle  .libs/findcomp.o .libs/libcc1.o .libs/libcp1.o .libs/compiler.o .libs/names.o .libs/callbacks.o .libs/connection.o .libs/marshall.o   -L/Users/leo/Gentoo/tmp/usr/lib  -m64 -Wl,-undefined -Wl,dynamic_lookup -nodefaultrpaths -nodefaultexport -Wl,-rpath -Wl,@loader_path -Wl,-search_paths_first ../libiberty/pic/libiberty.a   -Wl,-exported_symbols_list,.libs/libcc1-symbols.expsym
clang: error: unknown argument: '-nodefaultrpaths'
clang: error: unknown argument: '-nodefaultexport'
make[3]: *** [Makefile:576: libcc1.la] Error 1
make[3]: Leaving directory '/Users/leo/Gentoo/tmp/var/tmp/portage/sys-devel/gcc-12.2.0/work/build/libcc1'
make[3]: *** Waiting for unfinished jobs....
```

Currently, both `sys-devel/gcc-12.1.0` and `sys-devel/gcc-12.2.0` have problems. However, sys-devel/gcc-12.1.0 can be fixed after applying two patches, as I've described in Bug 895332. Meanwhile, the solution of this sys-devel/gcc-12.2.0 bug is unclear.

This commit masks sys-devel/gcc-12.2.0 on macOS for now until someone finishes investigation of the issue. Meanwhile, we can fix `sys-devel/gcc-12.1.0` according to Bug 895332. It would allow a successful bootstrap on macOS 13.2.

P.S: although the `KEYWORDS` says `~x64-macos`, it's actually also controlling the behavior of `~arm64-macos` as well.

### 2. Add two patches for sys-devel/gcc-12.1.0 to fix macOS 13 bootstrap

When bootstrapping Gentoo Prefix on macOS 13.2 (Ventura) on an Apple M1 system, it will fail at stage2 due to a GCC build failure because GCC 12.1 is incompatible with macOS 13.

```
make[2]: Entering directory '/Users/apple/gentoo/tmp/var/tmp/portage/sys-devel/gcc-12.1.0/work/build/gcc'
/Users/apple/Gentoo/tmp/var/tmp/portage/sys-devel/gcc-12.1.0/work/build/./gcc/xgcc -B/Users/apple/Gentoo/tmp/var/tmp/portage/sys-devel/g
cc-12.1.0/work/build/./gcc/ -xc++ -nostdinc /dev/null -S -o /dev/null -fself-test=/Users/apple/Gentoo/tmp/var/tmp/portage/sys-devel/gcc-
12.1.0/work/gcc-12-branch-gcc-12.1-darwin-r0/gcc/testsuite/selftests
<built-in>: error: unknown value '13.0' of '-mmacosx-version-min'
```

This problem can be fixed by applying the upstream patch

* Darwin: Future-proof -mmacosx-version-min
> f18cbc1ee1f4 (2021-12-18) updated various parts of gcc to not impose a
> Darwin or macOS version maximum of the current known release. [...] However,
> f18cbc1ee1f4 missed config/darwin-c.c (now .cc), which continued to impose a
> maximum of macOS 12 on the -mmacosx-version-min compiler driver argument.
https://github.com/gcc-mirror/gcc/commit/6725f186cb70d48338f69456864bf469a12ee5be.patch

However, there's another separate name collision bug in `fs_path.h` of `libstdc++` that will produce another error, similar to the following (I lost the original logs, this is copied from an issue I found online).

```
In file included from /private/tmp/gccA10-20221211-4993-1miwm67/gcc-10.4.0/build/x86_64-apple-darwin22/libstdc++-v3/include/filesystem:45,
                 from ../../../../../libstdc++-v3/src/c++17/fs_dir.cc:30:
/private/tmp/gccA10-20221211-4993-1miwm67/gcc-10.4.0/build/x86_64-apple-darwin22/libstdc++-v3/include/bits/fs_path.h:133:30: error: abstract declarator 'std::filesystem::__cxx11::__detail::<unnamed struct>' used as declaration
  133 |   struct __null_terminated { };
```
To fix this problem, the following upstream patch must be applied:

* libstdc++: Rename __null_terminated to avoid collision with Apple SDK
> The macOS 13 SDK (and equivalent-version iOS and other Apple OS SDKs)
> contain this definition in <sys/cdefs.h>: "#define __null_terminated" This
> collides with the use of __null_terminated in libstdc++'s experimental
> fs_path.h.
https://github.com/gcc-mirror/gcc/commit/d1201dbf55a11d391030914985ba6b443e59baa5.patch

Fixing both problems allow successful compile of sys-devel/gcc-12.1.0 in
stage2 and stage3. This commit fixes Gentoo bug 895332.

Note that sys-devel/gcc-12.2.0 has its own bugs (Gentoo bug 895334) that prevents bootstrapping from happening. My recommendation is fixing sys-devel/gcc-12.1.0 for now, and masking sys-devel/gcc-12.2.0 until the
problem has been thoroughly investigated.