### PR TITLE
Fix prefix python bootstrap for cygwin

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -997,9 +997,18 @@ bootstrap_gnu() {
 	einfo "${A%.tar.*} successfully bootstrapped"
 }
 
+if [[ ${CHOST} == *-cygwin* ]] ; then
+PYTHONMAJMIN=3.9   # keep this number in line with PV below for stage1,2
+else
 PYTHONMAJMIN=3.10   # keep this number in line with PV below for stage1,2
+fi
+
 bootstrap_python() {
-	PV=3.10.4
+	if [[ ${CHOST} == *-cygwin* ]] ; then
+          PV=3.9.9
+        else
+	  PV=3.10.4
+        fi
 	A=Python-${PV}.tar.xz
 	einfo "Bootstrapping ${A%.tar.*}"
 


### PR DESCRIPTION
Upstream cygwin doesn't ship python 3.10 yet, and the patches in the 3.9 tarball don't apply cleanly.
As a consequence, cygwin bootstrap has been broken since fd1c9f9b6b838173e6f7df0cb8cc5114e55f6c56. Fix this by using 3.9 to bootstrap for cygwin only.

Bug: https://bugs.gentoo.org/852665