### PR TITLE
scripts: Resolve shellcheck errors

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2,7 +2,7 @@
 # Copyright 2006-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-trap 'exit 1' TERM KILL INT QUIT ABRT
+trap 'exit 1' TERM INT QUIT ABRT
 
 # RAP (libc) mode is triggered on Linux kernel and glibc.
 is-rap() { [[ ${PREFIX_DISABLE_RAP} != "yes" && ${CHOST} = *linux-gnu* ]]; }
@@ -1666,7 +1666,7 @@ bootstrap_stage1() {
 }
 
 bootstrap_stage1_log() {
-	bootstrap_stage1 ${@} 2>&1 | tee -a ${ROOT}/stage1.log
+	bootstrap_stage1 "${@}" 2>&1 | tee -a ${ROOT}/stage1.log
 	local ret=${PIPESTATUS[0]}
 	[[ ${ret} == 0 ]] && touch ${ROOT}/.stage1-finished
 	return ${ret}
@@ -1961,7 +1961,7 @@ bootstrap_stage2() {
 }
 
 bootstrap_stage2_log() {
-	bootstrap_stage2 ${@} 2>&1 | tee -a ${ROOT}/stage2.log
+	bootstrap_stage2 "${@}" 2>&1 | tee -a ${ROOT}/stage2.log
 	local ret=${PIPESTATUS[0]}
 	[[ ${ret} == 0 ]] && touch "${ROOT}/.stage2-finished"
 	return ${ret}
@@ -2283,7 +2283,7 @@ bootstrap_stage3() {
 }
 
 bootstrap_stage3_log() {
-	bootstrap_stage3 ${@} 2>&1 | tee -a ${ROOT}/stage3.log
+	bootstrap_stage3 "${@}" 2>&1 | tee -a ${ROOT}/stage3.log
 	local ret=${PIPESTATUS[0]}
 	[[ ${ret} == 0 ]] && touch "${ROOT}/.stage3-finished"
 	return ${ret}
@@ -3191,7 +3191,9 @@ if [[ -z ${CHOST} ]]; then
 		case `uname -s` in
 			Linux)
 				plt="gnu"
-				[[ -e /lib/ld-musl-*.so.1 ]] && plt="musl"
+                                for f in /lib/ld-musl-*.so.1; do
+				  [[ -e "$f" ]] && plt="musl"
+                                done
 				sfx="unknown-linux-${plt}"
 				case `uname -m` in
 					ppc*)

--- a/scripts/rsync-generation/refresh-mirror.sh
+++ b/scripts/rsync-generation/refresh-mirror.sh
@@ -41,7 +41,7 @@ else
 	}
 	# get a free filedescriptor in FD
 	exec {FD}>/tmp/rsync-master-busy
-	(((genandpush | tee -a "${LOGFILE}") {FD}>&1 1>&2 2>&${FD} \
+	( ( (genandpush | tee -a "${LOGFILE}") {FD}>&1 1>&2 2>&${FD} \
 	    | tee -a "${LOGFILE}") 2> /dev/null)
 	echo "generation done $(date)" >> ${LOGFILE}
 	exec {FD}>&-


### PR DESCRIPTION
The action is failing at head, which makes it less than useful for evaluating new changes.

e.g.
Error: ./scripts/rsync-generation/refresh-mirror.sh:44:2: error: Shells disambiguate (( differently or not at all. For subshell, add spaces around ( . For ((, fix parsing errors. [SC1105] Error: ./scripts/rsync-generation/refresh-mirror.sh:44:3: error: Shells disambiguate (( differently or not at all. For subshell, add spaces around ( . For ((, fix parsing errors. [SC1105] Error: ./scripts/bootstrap-prefix.sh:5:20: error: SIGKILL/SIGSTOP can not be trapped. [SC2173] Error: ./scripts/bootstrap-prefix.sh:1669:19: error: Double quote array expansions to avoid re-splitting elements. [SC2068] Error: ./scripts/bootstrap-prefix.sh:1964:19: error: Double quote array expansions to avoid re-splitting elements. [SC2068] Error: ./scripts/bootstrap-prefix.sh:2286:19: error: Double quote array expansions to avoid re-splitting elements. [SC2068] Error: ./scripts/bootstrap-prefix.sh:3194:11: error: -e doesn't work with globs. Use a for loop. [SC2144]