### PR TITLE
Use gcc --sysroot in rap stage3 post glibc install

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2111,13 +2111,11 @@ bootstrap_stage3() {
 		)
 		# use the new dynamic linker in place of rpath from now on.
 		RAP_DLINKER=$(echo "${ROOT}"/$(get_libdir)/ld*.so.[0-9] | sed s"!${ROOT}/$(get_libdir)/ld-lsb.*!!")
-		export LDFLAGS="-L${ROOT}/usr/$(get_libdir) -Wl,--dynamic-linker=${RAP_DLINKER}"
-		if [[ ${compiler_type} == gcc ]] ; then
-			# make sure these flags are used even in places that ignore/strip CPPFLAGS/LDFLAGS
-			export LDFLAGS="-B${ROOT}/usr/$(get_libdir) ${LDFLAGS}"
-			export CC="gcc ${CPPFLAGS} ${LDFLAGS}"
-			export CXX="g++ ${CPPFLAGS} ${LDFLAGS}"
-		fi
+		export CPPFLAGS="--sysroot=${ROOT}"
+		export LDFLAGS="-Wl,--dynamic-linker=${RAP_DLINKER}"
+		# make sure these flags are used even in places that ignore/strip CPPFLAGS/LDFLAGS
+		export CC="gcc ${CPPFLAGS} ${LDFLAGS}"
+		export CXX="g++ ${CPPFLAGS} ${LDFLAGS}"
 		BOOTSTRAP_RAP=yes \
 		pre_emerge_pkgs --nodeps "${pkgs[@]}" || return 1
 


### PR DESCRIPTION
Since glibc now has non-prefixed filenames in
`$EPREFIX/usr/lib64/libc.so`, it picks up non-prefixed `/lib64/libc.so.6` from stage2 gcc, unless we replace its -I, -L, and -B options by --sysroot. Then it will look at the same places as the future stage3 gcc.

This avoids issues building binutils, which can't find dlopen in older `/lib64/libc.so.6`, since dlopen used to be in `libdl` instead.

The whole logic no longer tests for compiler == gcc, since clang is only used for non-rap on MacOS.