### PR TITLE
workaround for Bug 901101

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2245,7 +2245,8 @@ bootstrap_stage3() {
 	fi
 
 	# Avoid installing git or encryption just for fun while completing @system
-	export USE="-git -crypt"
+	# Avoid using http2 as a temporary work around Bug 901101 
+	export USE="-git -crypt -http2"
 
 	# Portage should figure out itself what it needs to do, if anything.
 	einfo "running emerge -uDNv system"


### PR DESCRIPTION
2248,2250c2248,2250
< 	# Avoid using http2 Bug 901101 
< 	export USE="-git -crypt -http2"
< 
---
> 	
> 	export USE="-git -crypt"