### PR TITLE
Fix Gentoo Prefix bootstrap with GCC 12.2 on macOS

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -1893,13 +1893,37 @@ bootstrap_stage2() {
 	EXTRA_ECONF=$(rapx --with-sysroot=/) \
 	emerge_pkgs --nodeps ${linker} || return 1
 
+	# During Gentoo prefix bootstrap stage2, GCC is built with
+	# "--disable-bootstrap". For Darwin, it means that rather than letting
+	# GCC to eventually build itself using multiple passes, we're forcing
+	# it to build with the host LLVM/clang toolchain in a single pass.
+	# It's not officially supported, but practically it worked. However,
+	# since >=gcc-12.2.0, in order to support the new embedded rpath
+	# feature on Darwin, two incompatible options, "-nodefaultrpaths" and
+	# "-nodefaultexport" are introduced. This causes linking failures,
+	# since these options are only recognized by GCC and are unknown to
+	# LLVM/clang (hypothetically, using an older GCC possibly causes the
+	# same problem as well).
+	#
+	# Thus, embedded rpath should be disabled during prefix bootstrap stage2
+	# and passed into EXTRA_ECONF.
+	# https://bugs.gentoo.org/895334
+	if [[ ${CHOST} == *-darwin* ]] ;
+	then
+		local disable_darwin_rpath="--disable-darwin-at-rpath"
+	else
+		local disable_darwin_rpath=""
+	fi
+
 	for pkg in ${compiler_stage1} ; do
 		# <glibc-2.5 does not understand .gnu.hash, use
 		# --hash-style=both to produce also sysv hash.
 		# GCC apparently drops CPPFLAGS at some point, which makes it
 		# not find things like gmp which we just installed, so force it
 		# to find our prefix
-		EXTRA_ECONF="--disable-bootstrap $(rapx --with-linker-hash-style=both) --with-local-prefix=${ROOT}" \
+		# For >=gcc-12.2.0, rpath needs to be disabled in stage2 on
+		# Darwin, see above.
+		EXTRA_ECONF="--disable-bootstrap $(rapx --with-linker-hash-style=both) --with-local-prefix=${ROOT} ${disable_darwin_rpath}" \
 		MYCMAKEARGS="-DCMAKE_USE_SYSTEM_LIBRARY_LIBUV=OFF" \
 		GCC_MAKE_TARGET=all \
 		OVERRIDE_CXXFLAGS="${CPPFLAGS} -O2 -pipe" \

--- a/sys-devel/gcc/gcc-12.2.0.ebuild
+++ b/sys-devel/gcc/gcc-12.2.0.ebuild
@@ -15,7 +15,7 @@ inherit toolchain
 if ! tc_is_live && [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	# fails to compile on Solaris and macOS, need to check why
 	: KEYWORDS="~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-	KEYWORDS="~x64-solaris ~x86-solaris"
+	KEYWORDS="~arm64-macos ~x64-macos ~x64-solaris ~x86-solaris"
 fi
 
 # use alternate source for Apple M1 (also works for x86_64)


### PR DESCRIPTION
This Pull Request introduces two changes. Merging both commits allows us to close [Bug 895334](https://bugs.gentoo.org/show_bug.cgi?id=895334).

* bootstrap-prefix.sh: use `--disable-darwin-at-rpath` in stage2

    During Gentoo prefix bootstrap stage2, GCC is built with `--disable-bootstrap`. For Darwin, it means that rather than letting GCC to eventually build itself using multiple passes, we're forcing it to build with the host LLVM/clang toolchain in a single pass. It's not officially supported, but practically it worked. However, since >=gcc-12.2.0, in order to support the new embedded rpath feature on Darwin, two incompatible options, `-nodefaultrpaths` and `-nodefaultexport` are introduced. This causes linking failures, since these options are only recognized by GCC and are unknown to LLVM/clang (hypothetically, using an older GCC possibly causes the same problem as well).

    Thus, embedded rpath should be disabled during prefix bootstrap stage2 via `--disable-darwin-at-rpath` in `EXTRA_ECONF`. Passing it to an earlier GCC version is also tested and shown to be harmless, as expected.

* sys-devel/gcc-12.2.0: unmask macOS.

    This commit reintroduces the keywords for macOS on both x64 and ARM64, which were previously masked. In the previous commit, the bootstrap script has been patched to allow the use of sys-devel/gcc-12.2.0 on macOS. The previous mask is no longer necessary.