### PR TITLE
dev-lang/python-3.11.3: fix build on macOS.

### DIFF
--- a/dev-lang/python/files/python-3.11.3-gcc-fallbacks-for-mkfifo-mknod-checks.patch
+++ b/dev-lang/python/files/python-3.11.3-gcc-fallbacks-for-mkfifo-mknod-checks.patch
@@ -1,0 +1,32 @@
+https://bugs.gentoo.org/905618
+https://github.com/python/cpython/issues/104106
+https://github.com/python/cpython/pull/104129
+
+From 6fc35af351b61e795c8ef6e10ff0f22a71130542 Mon Sep 17 00:00:00 2001
+From: Dong-hee Na <donghee.na@python.org>
+Date: Wed, 3 May 2023 20:35:42 +0900
+Subject: [PATCH 1/2] gh-104106: Add gcc fallback of mkfifoat/mknodat for macOS
+
+---
+ Modules/posixmodule.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+index dcb5e7a0e040..b395c265c72d 100644
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -175,6 +175,14 @@
+ #    define HAVE_PWRITEV_RUNTIME (pwritev != NULL)
+ #  endif
+ 
++#  ifdef HAVE_MKFIFOAT
++#    define HAVE_MKFIFOAT_RUNTIME (mkfifoat != NULL)
++#  endif
++
++#  ifdef HAVE_MKNODAT
++#    define HAVE_MKNODAT_RUNTIME (mknodat != NULL)
++#  endif
++
+ #endif
+ 
+ #ifdef HAVE_FUTIMESAT

--- a/dev-lang/python/python-3.11.3.ebuild
+++ b/dev-lang/python/python-3.11.3.ebuild
@@ -50,7 +50,7 @@ RDEPEND="
 	>=dev-libs/expat-2.1:=
 	dev-libs/libffi:=
 	dev-python/gentoo-common
-	sys-apps/util-linux:=
+	kernel_linux? ( sys-apps/util-linux:= )
 	>=sys-libs/zlib-1.1.3:=
 	virtual/libcrypt:=
 	virtual/libintl
@@ -127,6 +127,8 @@ src_prepare() {
 		"${WORKDIR}/${PATCHSET}"
 		# Prefix' round of patches
 		"${WORKDIR}"/${PREFIX_PATCHSET}
+
+		"${FILESDIR}"/${PN}-3.11.3-gcc-fallbacks-for-mkfifo-mknod-checks.patch
 	)
 
 	default


### PR DESCRIPTION
<del>Currently, dev-lang/python-3.11.3 is unbuildable on macOS for two reasons. First, due to a hardcoded dependency sys-apps/util-linux. This commit fixes it by conditionally requiring sys-apps/util-linux only on "kernel_linux".</del>

Another problem is that there exists two "#ifdef" checks for the system calls mkfifoat() and mknodat(), which are not compatible with GCC. Because they're defined using the __builtin_available() function - specific to clang without a fallback for GCC, they're never defined, thus creating the following errors:

    ./Modules/posixmodule.c:15647:23: error: 'HAVE_MKFIFOAT_RUNTIME'
    undeclared (first use in this function); did you mean
    'HAVE_MKDIRAT_RUNTIME'?
    ./Modules/posixmodule.c:15651:22: error: 'HAVE_MKNODAT_RUNTIME'
    undeclared (first use in this function); did you mean
    'HAVE_MKDIRAT_RUNTIME'?

These two checks were originally introduced to fix the problem that building Python on the macOS 13 SDK but running it on an earlier macOS version would result in a segfault. Since moving Gentoo Prefix in this manner is not supported, as a temporary fix, we simply revert this patch. Since this change only has an effect on macOS, it's safe to apply it without checking whether we're running on Darwin.

Closes: https://bugs.gentoo.org/905618