### PR TITLE
dev-libs/libbsd: port to Darwin.

### DIFF
--- a/dev-libs/libbsd/files/libbsd-0.9.1-darwin.patch
+++ b/dev-libs/libbsd/files/libbsd-0.9.1-darwin.patch
@@ -1,0 +1,364 @@
+https://github.com/NixOS/nixpkgs/blob/7c61bb615a3bcda46534436fd3136ef6103f3505/pkgs/development/libraries/libbsd/darwin.patch
+https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/libraries/libbsd
+
+diff --git a/configure.ac b/configure.ac
+index 55fcfe6..1e26c93 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -51,15 +51,19 @@ AS_CASE([$host_os],
+     AC_SEARCH_LIBS([clock_gettime], [rt], [CLOCK_GETTIME_LIBS="-lrt"])
+     AC_SUBST([CLOCK_GETTIME_LIBS])
+     LIBS="$saved_LIBS"
++    AM_CONDITIONAL([BUILD_LINK_VERSION_SCRIPT], [1])
+   ],
+   [*-musl*], [
+     # Upstream refuses to define this, we will do it ourselves then.
+     AC_DEFINE([__MUSL__], [1], [Define to 1 if we are building for musl])
++    AM_CONDITIONAL([BUILD_LINK_VERSION_SCRIPT], [1])
+   ],
+-)
++  [
++  AM_CONDITIONAL([BUILD_LINK_VERSION_SCRIPT], [1])
++  ])
+ 
+ # Checks for header files.
+-AC_CHECK_HEADERS([sys/ndir.h sys/dir.h ndir.h dirent.h])
++AC_CHECK_HEADERS([sys/ndir.h sys/dir.h ndir.h dirent.h nlist.h])
+ 
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_INLINE
+@@ -143,7 +147,8 @@ AC_LINK_IFELSE(
+ 
+ AC_CHECK_FUNCS([clearenv dirfd fopencookie __fpurge \
+                 getauxval getentropy getexecname getline \
+-                pstat_getproc sysconf])
++                pstat_getproc sysconf \
++		strlcpy strlcat strnstr strmode fpurge])
+ AM_CONDITIONAL([HAVE_GETENTROPY], [test "x$ac_cv_func_getentropy" = "xtrue"])
+ 
+ AC_CONFIG_FILES([
+diff --git a/include/bsd/string.h b/include/bsd/string.h
+index f987fee..a1e17ed 100644
+--- a/include/bsd/string.h
++++ b/include/bsd/string.h
+@@ -41,10 +41,21 @@
+ #include <sys/types.h>
+ 
+ __BEGIN_DECLS
++#if !HAVE_STRLCPY
+ size_t strlcpy(char *dst, const char *src, size_t siz);
++#endif
++
++#if !HAVE_STRLCAT
+ size_t strlcat(char *dst, const char *src, size_t siz);
++#endif
++
++#if !HAVE_STRNSTR
+ char *strnstr(const char *str, const char *find, size_t str_len);
++#endif
++
++#if !HAVE_STRMODE
+ void strmode(mode_t mode, char *str);
++#endif
+ 
+ #if !defined(__GLIBC__) || \
+     (defined(__GLIBC__) && (!__GLIBC_PREREQ(2, 25) || !defined(_GNU_SOURCE)))
+diff --git a/src/Makefile.am b/src/Makefile.am
+index f3cc0fa..3aaecd4 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -56,8 +56,10 @@ libbsd_la_DEPENDENCIES = \
+ libbsd_la_LIBADD = \
+ 	$(CLOCK_GETTIME_LIBS)
+ libbsd_la_LDFLAGS = \
+-	-Wl,--version-script=$(srcdir)/libbsd.map \
+ 	-version-number $(LIBBSD_ABI)
++if BUILD_LINK_VERSION_SCRIPT
++libbsd_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libbsd.map
++endif
+ libbsd_la_SOURCES = \
+ 	arc4random.c \
+ 	arc4random.h \
+diff --git a/src/fpurge.c b/src/fpurge.c
+index 462535a..a8941db 100644
+--- a/src/fpurge.c
++++ b/src/fpurge.c
+@@ -26,9 +26,10 @@
+ 
+ #include <errno.h>
+ #include <stdio.h>
+-#include <stdio_ext.h>
+ 
+ #ifdef HAVE___FPURGE
++#include <stdio_ext.h>
++
+ int
+ fpurge(FILE *fp)
+ {
+@@ -41,6 +42,36 @@ fpurge(FILE *fp)
+ 
+ 	return 0;
+ }
++/* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin 1.7 */
++#elif HAVE_FPURGE
++int
++fpurge(FILE *fp)
++{
++	if (fp == NULL || fileno(fp) < 0) {
++		errno = EBADF;
++		return EOF;
++	}
++
++  /* Call the system's fpurge function.  */
++#undef fpurge
++#if !HAVE_DECL_FPURGE
++  extern int fpurge (FILE *);
++#endif
++  int result = fpurge (fp);
++/* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
++#if defined(__sferror) || defined(__DragonFly__)
++  if (result == 0)
++    /* Correct the invariants that fpurge broke.
++       <stdio.h> on BSD systems says:
++         "The following always hold: if _flags & __SRD, _w is 0."
++       If this invariant is not fulfilled and the stream is read-write but
++       currently reading, subsequent putc or fputc calls will write directly
++       into the buffer, although they shouldn't be allowed to.  */
++    if ((fp->_flags & __SRD) != 0)
++      fp->_w = 0;
++#endif
++  return result;
++}
+ #else
+ #error "Function fpurge() needs to be ported."
+ #endif
+diff --git a/src/funopen.c b/src/funopen.c
+index 1e05c7e..65ba5a8 100644
+--- a/src/funopen.c
++++ b/src/funopen.c
+@@ -143,6 +143,7 @@ funopen(const void *cookie,
+  * they will not add the needed support to implement it. Just ignore this
+  * interface there, as it has never been provided anyway.
+  */
++#elif defined(__MACH__)
+ #else
+ #error "Function funopen() needs to be ported or disabled."
+ #endif
+diff --git a/src/hash/sha512.h b/src/hash/sha512.h
+index 4f368a1..7632e25 100644
+--- a/src/hash/sha512.h
++++ b/src/hash/sha512.h
+@@ -29,7 +29,11 @@
+ #ifndef _SHA512_H_
+ #define _SHA512_H_
+ 
++#ifdef __MACH__
++#include <stdint.h>
++#else
+ #include <sys/types.h>
++#endif
+ 
+ #define SHA512_DIGEST_LENGTH		64
+ 
+diff --git a/src/hash/sha512c.c b/src/hash/sha512c.c
+index b3c8d5e..602f54e 100644
+--- a/src/hash/sha512c.c
++++ b/src/hash/sha512c.c
+@@ -25,7 +25,12 @@
+  */
+ 
+ #include <sys/cdefs.h>
++
++#ifdef __MACH__
++#include <machine/endian.h>
++#else
+ #include <sys/endian.h>
++#endif
+ #include <sys/types.h>
+ 
+ #include <string.h>
+diff --git a/src/local-link.h b/src/local-link.h
+index d518dcf..84694a2 100644
+--- a/src/local-link.h
++++ b/src/local-link.h
+@@ -27,7 +27,11 @@
+ #ifndef LIBBSD_LOCAL_LINK_H
+ #define LIBBSD_LOCAL_LINK_H
+ 
++#ifdef __MACH__
++#define libbsd_link_warning(symbol, msg)
++#else
+ #define libbsd_link_warning(symbol, msg) \
+ 	static const char libbsd_emit_link_warning_##symbol[] \
+ 		__attribute__((used,section(".gnu.warning." #symbol))) = msg;
+ #endif
++#endif
+diff --git a/src/nlist.c b/src/nlist.c
+index 0932f59..4502048 100644
+--- a/src/nlist.c
++++ b/src/nlist.c
+@@ -41,6 +41,7 @@
+ #include <unistd.h>
+ #include <nlist.h>
+ 
++#if !HAVE_NLIST_H
+ #include "local-elf.h"
+ 
+ #define SIZE_T_MAX 0xffffffffU
+@@ -265,3 +266,4 @@ nlist(const char *name, struct nlist *list)
+ 	(void)close(fd);
+ 	return (n);
+ }
++#endif
+diff --git a/src/readpassphrase.c b/src/readpassphrase.c
+index f9f6195..2bc5fb4 100644
+--- a/src/readpassphrase.c
++++ b/src/readpassphrase.c
+@@ -36,6 +36,14 @@
+ #define TCSASOFT 0
+ #endif
+ 
++#ifndef _SIGMAX
++#define	_SIGMAX	64
++#endif
++
++#ifndef _NSIG
++#define _NSIG (_SIGMAX + 1)
++#endif
++
+ static volatile sig_atomic_t signo[_NSIG];
+ 
+ static void handler(int);
+diff --git a/src/setproctitle.c b/src/setproctitle.c
+index 038ac7d..e9ee09c 100644
+--- a/src/setproctitle.c
++++ b/src/setproctitle.c
+@@ -32,6 +32,10 @@
+ #include <unistd.h>
+ #include <string.h>
+ 
++#ifdef __MACH__
++extern char **environ;
++#endif
++
+ static struct {
+ 	/* Original value. */
+ 	const char *arg0;
+@@ -280,16 +284,22 @@ setproctitle_impl(const char *fmt, ...)
+ 		*++nul = '\0';
+ 	}
+ }
++#ifndef __MACH__
+ __asm__(".symver setproctitle_impl,setproctitle@@LIBBSD_0.5");
++#endif
+ 
+ /* The original function introduced in 0.2 was a stub, it only got implemented
+  * in 0.5, make the implementation available in the old version as an alias
+  * for code linking against that version, and change the default to use the
+  * new version, so that new code depends on the implemented version. */
+-#ifdef HAVE_TYPEOF
++#ifdef __MACH__
++void setproctitle_stub(const char *fmt, ...);
++#elif HAVE_TYPEOF
+ extern typeof(setproctitle_impl) setproctitle_stub __attribute__((alias("setproctitle_impl")));
+ #else
+ void setproctitle_stub(const char *fmt, ...)
+ 	__attribute__((alias("setproctitle_impl")));
+ #endif
++#ifndef __MACH__
+ __asm__(".symver setproctitle_stub,setproctitle@LIBBSD_0.2");
++#endif
+diff --git a/src/strlcat.c b/src/strlcat.c
+index 14c53a1..5961c17 100644
+--- a/src/strlcat.c
++++ b/src/strlcat.c
+@@ -26,6 +26,7 @@
+  * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
+  * If retval >= dsize, truncation occurred.
+  */
++#if !HAVE_STRLCAT
+ size_t
+ strlcat(char *dst, const char *src, size_t dsize)
+ {
+@@ -53,3 +54,4 @@ strlcat(char *dst, const char *src, size_t dsize)
+ 
+ 	return(dlen + (src - osrc));	/* count does not include NUL */
+ }
++#endif
+diff --git a/src/strlcpy.c b/src/strlcpy.c
+index e9a7fe4..5137acb 100644
+--- a/src/strlcpy.c
++++ b/src/strlcpy.c
+@@ -24,6 +24,7 @@
+  * chars will be copied.  Always NUL terminates (unless dsize == 0).
+  * Returns strlen(src); if retval >= dsize, truncation occurred.
+  */
++#if !HAVE_STRLCPY
+ size_t
+ strlcpy(char *dst, const char *src, size_t dsize)
+ {
+@@ -48,3 +49,4 @@ strlcpy(char *dst, const char *src, size_t dsize)
+ 
+ 	return(src - osrc - 1);	/* count does not include NUL */
+ }
++#endif
+diff --git a/src/strmode.c b/src/strmode.c
+index e6afde5..da680c9 100644
+--- a/src/strmode.c
++++ b/src/strmode.c
+@@ -32,6 +32,7 @@
+ #include <sys/stat.h>
+ #include <string.h>
+ 
++#if !HAVE_STRMODE
+ void
+ strmode(mode_t mode, char *p)
+ {
+@@ -141,3 +142,4 @@ strmode(mode_t mode, char *p)
+ 	*p++ = ' ';		/* will be a '+' if ACL's implemented */
+ 	*p = '\0';
+ }
++#endif
+diff --git a/src/unvis.c b/src/unvis.c
+index 94e3e7a..fba4c66 100644
+--- a/src/unvis.c
++++ b/src/unvis.c
+@@ -565,11 +565,15 @@ strnunvis_openbsd(char *dst, const char *src, size_t dlen)
+ {
+ 	return strnunvisx(dst, dlen, src, 0);
+ }
++#ifndef __MACH__
+ __asm__(".symver strnunvis_openbsd,strnunvis@@LIBBSD_0.2");
++#endif
+ 
+ int
+ strnunvis_netbsd(char *dst, size_t dlen, const char *src)
+ {
+ 	return strnunvisx(dst, dlen, src, 0);
+ }
++#ifndef __MACH__
+ __asm__(".symver strnunvis_netbsd,strnunvis@LIBBSD_0.9.1");
++#endif
+diff --git a/src/vis.c b/src/vis.c
+index c2cd2d8..2d84330 100644
+--- a/src/vis.c
++++ b/src/vis.c
+@@ -723,14 +723,18 @@ strnvis_openbsd(char *mbdst, const char *mbsrc, size_t dlen, int flags)
+ {
+ 	return istrsenvisxl(&mbdst, &dlen, mbsrc, flags, "", NULL);
+ }
++#ifndef __MACH__
+ __asm__(".symver strnvis_openbsd,strnvis@@LIBBSD_0.2");
++#endif
+ 
+ int
+ strnvis_netbsd(char *mbdst, size_t dlen, const char *mbsrc, int flags)
+ {
+ 	return istrsenvisxl(&mbdst, &dlen, mbsrc, flags, "", NULL);
+ }
++#ifndef __MACH__
+ __asm__(".symver strnvis_netbsd,strnvis@LIBBSD_0.9.1");
++#endif
+ 
+ int
+ stravis(char **mbdstp, const char *mbsrc, int flags)

--- a/dev-libs/libbsd/libbsd-0.9.1.ebuild
+++ b/dev-libs/libbsd/libbsd-0.9.1.ebuild
@@ -10,11 +10,15 @@ SRC_URI="https://${PN}.freedesktop.org/releases/${P}.tar.xz"
 
 LICENSE="BSD BSD-2 BSD-4 ISC"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~x64-macos"
 IUSE="static-libs"
 
 DEPEND="|| ( >=sys-kernel/linux-headers-3.17 virtual/os-headers )"
 RDEPEND=""
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.1-darwin.patch
+)
 
 pkg_setup() {
 	local f="${EROOT}/usr/$(get_libdir)/${PN}.a"


### PR DESCRIPTION
This commit allows dev-libs/libbsd-0.9.1 to be built on Darwin (which is a dependency of many useful packages), thanks to the patch from NixOS.