### PR TITLE
Troubles noticed on ancient hosts (CentOS 7)

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -1972,9 +1972,11 @@ bootstrap_stage3() {
 
 	# pre_emerge_pkgs relies on stage 2 portage.
 	pre_emerge_pkgs() {
-		is-rap \
-			&& without_stack_emerge_pkgs "$@" \
-			|| with_stack_emerge_pkgs "$@"
+		if is-rap; then
+			without_stack_emerge_pkgs "$@"
+		else
+			with_stack_emerge_pkgs "$@"
+		fi
 	}
 
 	# Some packages fail to properly depend on sys-apps/texinfo.

--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2045,6 +2045,7 @@ bootstrap_stage3() {
 		fi
 
 		pkgs=(
+			sys-devel/gnuconfig
 			sys-apps/baselayout
 			sys-apps/gentoo-functions
 			app-portage/elt-patches
@@ -2085,6 +2086,7 @@ bootstrap_stage3() {
 		pre_emerge_pkgs --nodeps "${pkgs[@]}" || return 1
 	else
 		pkgs=(
+			sys-devel/gnuconfig
 			sys-apps/gentoo-functions
 			app-portage/elt-patches
 			app-arch/xz-utils


### PR DESCRIPTION
Hi!

The current bootstrap script fails to build a prefix on CentOS since it insists on using host tools via the base-layout 99host file, which leads to the wrong tools being used.  We have a fully functioning toolchain at that point that we should be using, it just ends up being in path too late.  To fix this, we can inject the stage2 PATH into the stage3 PATH just before 99host gets to add the fallback.

I also noticed some minor missing things (gnuconfig not being installed early, and some 'compact' logic nuking work directories at unfortunate times, causing hours of confusion ;) ).

This patchset addresses all of the above.