### PR TITLE
scripts/bootstrap-prefix: don't create invalid symlinks

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -619,7 +619,7 @@ bootstrap_startscript() {
 prepare_portage() {
 	# see bootstrap_portage for explanations.
 	mkdir -p "${ROOT}"/usr/bin/. "${ROOT}"/var/log
-	ln -sf usr/bin "${ROOT}"/bin
+	[[ -x ${ROOT}/bin ]] || ln -s usr/bin "${ROOT}"/bin
 	[[ -x ${ROOT}/bin/bash ]] || ln -s "${ROOT}"{/tmp,}/bin/bash || return 1
 	[[ -x ${ROOT}/bin/sh ]] || ln -s bash "${ROOT}"/bin/sh || return 1
 }
@@ -2374,7 +2374,7 @@ bootstrap_stage3() {
 	# than to fake it here for the time being like in stage2.
 	if [[ ! -e "${ROOT}"/lib/gentoo/functions.sh ]] ; then
 		mkdir -p "${ROOT}"/usr/lib/gentoo
-		ln -sf usr/lib "${ROOT}"/lib
+		[[ -x ${ROOT}/lib ]] || ln -s usr/lib "${ROOT}"/lib
 		cp "${ROOT}"/tmp/lib/gentoo/functions.sh \
 			"${ROOT}"/lib/gentoo/functions.sh
 	fi


### PR DESCRIPTION
Check if ${ROOT}/bin and ${ROOT}/lib exist before creating symlinks to ${ROOT}/usr.