### PR TITLE
scripts/bootstrap-prefix: set PORTAGE_USERNAME and PORTAGE_GRPNAME

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -319,6 +319,8 @@ bootstrap_setup() {
 				# mainline Portage doesn't set these like Prefix branch
 				# does, so hardwire the IDs here
 				echo
+				echo "PORTAGE_USERNAME=$(id --name --user)"
+				echo "PORTAGE_GRPNAME=$(id --name --group)"
 				echo "PORTAGE_INST_UID=$(id --user)"
 				echo "PORTAGE_INST_GID=$(id --group)"
 			fi


### PR DESCRIPTION
Portage requires these variables to be set to grab the proper GID for running chown on edb files.