### PR TITLE
scripts/bootstrap-prefix: fix >=python-3.14

### DIFF
--- a/dev-lang/python/python-3.14.5.ebuild
+++ b/dev-lang/python/python-3.14.5.ebuild
@@ -41,7 +41,7 @@ if [[ ${PV} != *_rc* ]]; then
 fi
 IUSE="
 	bluetooth debug +ensurepip examples gdbm jit libedit +ncurses pgo
-	+readline +sqlite +ssl tail-call-interp test tk valgrind
+	+readline +sqlite +ssl tail-call-interp test tk valgrind build
 "
 REQUIRED_USE="jit? ( ${LLVM_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
@@ -54,7 +54,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="
 	app-arch/bzip2:=
 	app-arch/xz-utils:=
-	app-arch/zstd:=
+	!build? ( app-arch/zstd:= )
 	app-misc/mime-types
 	>=dev-libs/expat-2.1:=
 	dev-libs/libffi:=
@@ -473,6 +473,7 @@ src_configure() {
 		$(usev !ncurses '_curses _curses_panel')
 		$(usev !readline 'readline')
 		$(usev !tk '_tkinter')
+		$(usev build '_zstd')
 		$([[ ${CHOST} == *-apple-darwin* ]] && echo '_scproxy')
 		$([[ ${CHOST} != *-linux-* ]] && echo 'ossaudiodev')
 	EOF

--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -2591,6 +2591,11 @@ bootstrap_stage3() {
 	TIME_T_32_BIT_OK=yes \
 	pre_emerge_pkgs "" "${pkgs[@]}" || return 1
 
+	# For python3.14+, which introduce zstd in stdlib, and also breaks the
+	# bootstrap here with circular deps. With USE=build we can skip that dep
+	USE=build \
+	pre_emerge_pkgs "" "dev-lang/python" || return 1
+
 	pkgs=(
 		virtual/os-headers
 		sys-devel/gettext


### PR DESCRIPTION
Recently Gentoo makes the python3_14 the default target, which breaks the stage3 bootstraping, because Python 3.14 makes zstd part of stdlib, and building zstd requires meson with Python, so circular dependencies here:

```
stage3.log: * Error: circular dependencies:
stage3.log-
stage3.log-(app-arch/zstd-1.5.7-r1:0/1::gentoo, ebuild scheduled for merge) depends on
stage3.log- (dev-build/meson-format-array-0:0/0::gentoo, ebuild scheduled for merge) (buildtime)
stage3.log-  (dev-lang/python-3.14.4_p1:3.14/3.14::gentoo, ebuild scheduled for merge) (runtime)
stage3.log-   (app-arch/zstd-1.5.7-r1:0/1::gentoo, ebuild scheduled for merge) (buildtime_slot_op)
```

Here is just a proposed fix way with USE=build flag to break the zstd requirements with Python (as ztrawhcse in IRC says) in stage3, and it works. But however, we need to patch all of the >=dev-lang/python-3.14 packages in upstream Gentoo ebuilds, so I think we may need to have more considerations?

P.S. I'm not sure whether to submit patches to Gentoo ebuilds :/