### PR TITLE
bootstrap-prefix: stop special USE flags for @system

### DIFF
--- a/scripts/bootstrap-prefix.sh
+++ b/scripts/bootstrap-prefix.sh
@@ -1896,6 +1896,24 @@ do_emerge_pkgs() {
 			"system-bootstrap"
 			"clang"
 			"internal-glib"
+			# USE-flags to disable during bootstrap for they produce
+			# unnecessary, or worse: circular deps
+			# - nghttp2 -> cmake -> curl -> nghttp2  (http2)      #901101
+			#   (not any more since nghttp2 uses autotools again since March 2025,
+			#    but a cmake user could return in the future)
+			# - ensurepip -> python -> ensurepip     (ensurepip)
+			# - binutils -> zstd -> meson -> python  (zstd)       #967234
+			# - >=python-3.14 -> zstd -> ... python  (build)
+			"-crypt"
+			"-curl_quic_openssl"  # curl
+			"-ensurepip"          # python-3.13
+			"-git"
+			"-http2"              # curl
+			"-http3"              # curl
+			"-quic"               # curl
+			"-zstd"               # binutils/gcc
+			"-debuginfod"         # binutils
+			"build"               # python-3.14
 		)
 
 		local skip_llvm_pkg_setup=
@@ -2623,12 +2641,6 @@ bootstrap_stage3() {
 		emerge --color n --sync || emerge-webrsync --no-pgp-verify || return 1
 	fi
 
-	# Avoid installing git or encryption just for fun while completing @system
-	# e.g. bug #901101, this is a reduced (e.g. as minimal as possible)
-	# set of DISABLE_USE, to set the stage for solving circular
-	# dependencies, such as:
-	export USE="${DISABLE_USE[*]}"
-
 	# Portage should figure out itself what it needs to do, if anything.
 	local eflags=( "--deep" "--update" "--changed-use" "@system" )
 	einfo "running emerge ${eflags[*]}"
@@ -2643,10 +2655,6 @@ bootstrap_stage3() {
 	# Remove the stage2 hack from above.  A future emerge run will
 	# get env-update to happen.
 	rm "${ROOT}"/etc/env.d/98stage2
-
-	# now try and get things in the way they should be according to the
-	# default USE-flags
-	unset USE
 
 	# re-emerge anything hopefully not running into circular deps
 	eflags=( "--deep" "--changed-use" "@world" )
@@ -2693,25 +2701,6 @@ set_helper_vars() {
 	GENTOO_MIRRORS=${GENTOO_MIRRORS:="http://distfiles.gentoo.org"}
 	SNAPSHOT_HOST=$(rapx http://distfiles.gentoo.org http://rsync.prefix.bitzolder.nl)
 	SNAPSHOT_URL=${SNAPSHOT_URL:-"${SNAPSHOT_HOST}/snapshots"}
-
-	# USE-flags to disable during bootstrap for they produce
-	# unnecessary, or worse: circular deps
-	# - nghttp2 -> cmake -> curl -> nghttp2  (http2)      #901101
-	# - ensurepip -> python -> ensurepip     (ensurepip)
-	# - binutils -> zstd -> meson -> python  (zstd)       #967234
-	# - >=python-3.14 -> zstd -> ... python  (build)
-	DISABLE_USE=(
-		"-crypt"
-		"-curl_quic_openssl"  # curl
-		"-ensurepip"          # python-3.13
-		"-git"
-		"-http2"              # curl
-		"-http3"              # curl
-		"-quic"               # curl
-		"-zstd"               # binutils/gcc
-		"-debuginfod"         # binutils
-		"build"               # python-3.14
-	)
 
 	export MAKE CONFIG_SHELL
 }
@@ -2794,6 +2783,7 @@ EOF
 		ROOT \
 		CPATH \
 		LIBRARY_PATH \
+		USE \
 	; do
 		[[ -n ${SETUP_ENV_ONLY} ]] && continue  # we already checked this
 		# starting on purpose a shell here iso ${!flag} because I want


### PR DESCRIPTION
This change simplifies USE flag handling because all circular dependencies are resolved before the `emerge @system`.

Since USE is then no longer exported in the script, it also makes sure USE is not set by the user before starting the bootstrap.

This avoids a time-consuming rebuild of GCC during stage3 `@world`; in fact `emerge @world` does nothing, but I kept it for now.

Some additional analysis:
from reading the script I saw it does the following (I could not find it documented elsewhere in detail) for RAP specifically:

stage1: build a temporary portage and its dependencies manually
stage2: use that temporary portage to build GCC (+deps)
stage3: build
a) glibc
b) binutils
c) gcc
d) portage
e) `@system`
f) `@world`
(+ deps)

up so far stage2 and 3a)-3d) use a long list of USE flags in `do_emerge_pkgs()` (`local myuse`), and additionally a set of flags in `DISABLE_USE`; stage 3e) then only uses `DISABLE_USE`. This patch merges the `DISABLE_USE` flags into `myuse` and stops using `DISABLE_USE` in stage 3e).

*Circular dependencies:*

there are 4 documented:
```
 - nghttp2 -> cmake -> curl -> nghttp2  (http2)      #901101
 - binutils -> zstd -> meson -> python  (zstd)       #967234
 - ensurepip -> python -> ensurepip     (ensurepip)
 - >=python-3.14 -> zstd -> ... python  (build)
```
The `nghttp2` one does not apply anymore  since nghttp2 uses autotools again since March 2025:
https://gitweb.gentoo.org/repo/gentoo.git/commit/net-libs/nghttp2?id=a7716d6ed1fbff2e7c27618aa2f7d24bc748f7d1
Of course a cmake user could return in the future. But cmake could then be resolved during stage3d)

The other ones already need to be resolved during stage 3b (binutils) and 3d (python), so no use still doing it during `@system`.

Comparison:

before:
```
@system: Total: 166 packages (145 new, 21 reinstalls)
@world: Total: 27 packages (18 new, 9 reinstalls)
```

after:
```
@system: Total: 187 packages (163 new, 24 reinstalls)
@world: Total: 0 packages
```

time for stage3 install (4 cores on a laptop): 5h32 vs 4h21.

I did not check this on non-RAP, it's possible I'm not aware of a gotcha somewhere.